### PR TITLE
fix #4 Set series names from row dimension values

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -68,7 +68,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
       const response = await this.post<TimeseriesResponse>(endpoint, body, '');
       fields.push({ name: 'Time', type: FieldType.time, values: response.data.t });
       response.data.rows.forEach((r, i) => {
-          fields.push({ type: FieldType.number, values: response.data.points[i], labels: this.buildLabels(target.dimensions!!, r), name: undefined });
+          fields.push({ type: FieldType.number, values: response.data.points[i], labels: this.buildLabels(target.dimensions!!, r), name: r.length ? r.join(' - ') : target.unit });
       });
     } else if (target.type === 'sankey') {
       const response = await this.post<SandkeyResponse>(endpoint, body, '');


### PR DESCRIPTION
Time series fields were created with name: undefined, causing Grafana to auto-assign generic names like "Field 0", "Field 1". Series with the same dimension values across queries got different auto-names and could not be linked or manipulated together.

Use the row's dimension values joined as the field name so series with identical dimensions share a stable, meaningful name. Falls back to the query unit when no dimensions are present.

Will fix issue 4